### PR TITLE
Handle EOF when lexing a filter expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Python JSONPath RFC 9535 Change Log
 
+## Version 0.1.2 (unreleased)
+
+**Fixes**
+
+- Handle end of query when lexing inside a filter expression.
+
 ## Version 0.1.1
 
 Fix PyPi classifiers and README.

--- a/jsonpath_rfc9535/lex.py
+++ b/jsonpath_rfc9535/lex.py
@@ -294,7 +294,11 @@ def lex_inside_filter(l: Lexer) -> Optional[StateFn]:  # noqa: D103, PLR0915, PL
         l.ignore_whitespace()
         c = l.next()
 
-        if c in ("", "]"):
+        if c == "":
+            l.error("unclosed bracketed selection")
+            return None
+
+        if c == "]":
             l.filter_depth -= 1
             if len(l.paren_stack) == 1:
                 l.error("unbalanced parentheses")

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -23,6 +23,13 @@ def test_unclosed_selection_list(env: JSONPathEnvironment) -> None:
         env.compile("$[1,2")
 
 
+def test_unclosed_selection_list_inside_filter(env: JSONPathEnvironment) -> None:
+    with pytest.raises(
+        JSONPathSyntaxError, match=r"unclosed bracketed selection, line 1, column 10"
+    ):
+        env.compile("$[?@.a < 1")
+
+
 def test_function_missing_param(env: JSONPathEnvironment) -> None:
     with pytest.raises(JSONPathTypeError):
         env.compile("$[?(length()==1)]")


### PR DESCRIPTION
Handle EOF when lexing a filter expression.