### PR TITLE
Fix unbalanced parentheses check

### DIFF
--- a/jsonpath_rfc9535/lex.py
+++ b/jsonpath_rfc9535/lex.py
@@ -299,10 +299,6 @@ def lex_inside_filter(l: Lexer) -> Optional[StateFn]:  # noqa: D103, PLR0915, PL
 
         if c == "]":
             l.filter_depth -= 1
-            if len(l.paren_stack) == 1:
-                l.error("unbalanced parentheses")
-                return None
-
             l.backup()
             return lex_inside_bracketed_segment
 
@@ -485,6 +481,9 @@ def tokenize(query: str) -> List[Token]:
     """Scan JSONPath expression _query_ and return a list of tokens."""
     lexer, tokens = lex(query)
     lexer.run()
+
+    if len(lexer.paren_stack) == 1:
+        raise JSONPathSyntaxError("unbalanced parentheses", token=tokens[-1])
 
     if tokens and tokens[-1].type_ == TokenType.ERROR:
         raise JSONPathSyntaxError(tokens[-1].message, token=tokens[-1])

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -85,6 +85,11 @@ def test_recursive_data_nondeterministic() -> None:
         env.find(query, data)
 
 
+def test_nested_functions_unbalanced_parens(env: JSONPathEnvironment) -> None:
+    with pytest.raises(JSONPathSyntaxError, match="unbalanced parentheses"):
+        env.compile("$.values[?match(@.a, value($..['regex'])]")
+
+
 class FilterLiteralTestCase(NamedTuple):
     description: str
     query: str

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1,0 +1,6 @@
+import jsonpath_rfc9535 as jsonpath
+
+
+def test_issue_13() -> None:
+    # This was failing with "unbalanced parentheses".
+    _q = jsonpath.compile("$[? count(@.likes[? @.location]) > 3]")


### PR DESCRIPTION
Provisionally move unbalanced parens check to end of tokenization.

There's a better way. If we were to keep track of all parens (not just function calls) and square brackets, we can get hold of the correct token and pass it to `JSONPathSyntaxError`.