### PR TITLE
Improve error messages related to unbalanced brackets

### DIFF
--- a/jsonpath_rfc9535/lex.py
+++ b/jsonpath_rfc9535/lex.py
@@ -509,9 +509,12 @@ def tokenize(query: str) -> List[Token]:
     lexer, tokens = lex(query)
     lexer.run()
 
-    # Check for remaining opening brackets that have not been closes.
+    if tokens and tokens[-1].type_ == TokenType.ERROR:
+        raise JSONPathSyntaxError(tokens[-1].message, token=tokens[-1])
+
+    # Check for remaining opening brackets that have not been closed.
     if lexer.bracket_stack:
-        ch, index = lexer.bracket_stack[0]
+        ch, index = lexer.bracket_stack[-1]
         msg = f"unbalanced {'brackets' if ch == '[' else 'parentheses'}"
         raise JSONPathSyntaxError(
             msg,
@@ -523,8 +526,5 @@ def tokenize(query: str) -> List[Token]:
                 msg,
             ),
         )
-
-    if tokens and tokens[-1].type_ == TokenType.ERROR:
-        raise JSONPathSyntaxError(tokens[-1].message, token=tokens[-1])
 
     return tokens

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ exclude = [
   "dist",
   "node_modules",
   "venv",
+  "tests/nts",
 ]
 
 # Same as Black.

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -18,14 +18,14 @@ def env() -> JSONPathEnvironment:
 
 def test_unclosed_selection_list(env: JSONPathEnvironment) -> None:
     with pytest.raises(
-        JSONPathSyntaxError, match=r"unbalanced brackets, line 1, column 1"
+        JSONPathSyntaxError, match=r"unbalanced brackets, line 1, column 5"
     ):
         env.compile("$[1,2")
 
 
 def test_unclosed_selection_list_inside_filter(env: JSONPathEnvironment) -> None:
     with pytest.raises(
-        JSONPathSyntaxError, match=r"unbalanced brackets, line 1, column 1"
+        JSONPathSyntaxError, match=r"unclosed bracketed selection, line 1, column 10"
     ):
         env.compile("$[?@.a < 1")
 


### PR DESCRIPTION
This PR improves error messages related to unbalanced brackets.

Previously we were inspecting `Lexer.bracket_stack` before looking for error tokens, which give more accurate line and column numbers.