### PR TITLE
Refactor `Lexer` to avoid `lex_string_factory`

### DIFF
--- a/jsonpath_rfc9535/exceptions.py
+++ b/jsonpath_rfc9535/exceptions.py
@@ -27,6 +27,7 @@ class JSONPathError(Exception):
         if not self.token:
             return msg
 
+        # TODO: Pretty error messages with current line and visual pointer.
         line, column = self.token.position()
         return f"{msg}, line {line}, column {column}"
 

--- a/jsonpath_rfc9535/lex.py
+++ b/jsonpath_rfc9535/lex.py
@@ -134,17 +134,12 @@ class Lexer:
     def accept_string_literal(self, quote: str, token_type: TokenType) -> bool:
         """Scan and emit a string literal token.
 
-        Return `True` is successful, or `False` otherwise, in which case an error token
-        will have been emitted.
+        Assumes the next character is equal to `quote`.
+
+        Return `True` is successful or `False` otherwise, in which case an error token
+        will have been emitted. The caller should treat `False` as an error condition.
         """
         self.ignore()  # ignore opening quote
-
-        if self.peek() == "":
-            # an empty string
-            self.emit(token_type)
-            self.next()
-            self.ignore()
-            return True
 
         while True:
             c = self.next()
@@ -162,7 +157,7 @@ class Lexer:
                 return False
 
             if c == quote:
-                self.backup()
+                self.backup()  # don't emit the closing quote
                 self.emit(token_type)
                 self.next()
                 self.ignore()  # ignore closing quote
@@ -186,7 +181,6 @@ class Lexer:
 
     def error(self, msg: str) -> None:
         """Emit an error token."""
-        # TODO: better error messages.
         self.tokens.append(
             Token(
                 TokenType.ERROR,

--- a/jsonpath_rfc9535/lex.py
+++ b/jsonpath_rfc9535/lex.py
@@ -8,7 +8,6 @@ from typing import List
 from typing import Optional
 from typing import Pattern
 from typing import Tuple
-from typing import TypeAlias
 
 from .exceptions import JSONPathLexerError
 from .exceptions import JSONPathSyntaxError
@@ -27,7 +26,7 @@ RE_FUNCTION_NAME = re.compile(r"[a-z][a-z_0-9]*")
 ESCAPES = frozenset(["b", "f", "n", "r", "t", "u", "/", "\\"])
 
 
-StateFn: TypeAlias = Callable[[], Optional["StateFn"]]
+StateFn = Callable[[], Optional["StateFn"]]
 
 
 class Lexer:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,17 @@ select = [
   "YTT",
 ]
 
-ignore = ["S105", "S101", "D107", "D105", "PLR0913", "SIM108", "PT001", "A005"]
+ignore = [
+  "S105",
+  "S101",
+  "D107",
+  "D105",
+  "PLR0913",
+  "SIM108",
+  "PT001",
+  "A005",
+  "PLW1641",
+]
 
 fixable = ["I"]
 unfixable = []


### PR DESCRIPTION
This PR replaces `lex_string_factory` with `accept_string_literal` and moves all state functions (`lex_*`) to be methods of `Lexer` instead of functions.

I have thought about using `functools.partialmethod` instead, but I'm not sure that's much better than the factory function.

The one downside to this approach is that `accept_string_literal` is not a true state function, but it does emit a token, which doesn't feel very neat. 